### PR TITLE
added ee field to inproceedings.

### DIFF
--- a/crosstex/objects.py
+++ b/crosstex/objects.py
@@ -208,6 +208,7 @@ class inproceedings(citeableref):
     address   = Field(types=(location, country, state))
     year      = Field()
     month     = Field(types=(month,))
+    ee        = Field()
 
 class manual(citeableref):
     title = Field(required=True)


### PR DESCRIPTION
dsn.xtx contains an "electronic edition" field containing the url to the pdf.  It causes crosstex to generate an annoying message that ee is not a field in inproceedings.
